### PR TITLE
Optimisation of EFT cache debug printing

### DIFF
--- a/eftcamb_apps/stability_sampler.F90
+++ b/eftcamb_apps/stability_sampler.F90
@@ -510,7 +510,7 @@ program stability_sampler
             end if
           end if
 
-    open(unit=1, name=trim(outroot) //'Stability_Space.dat', action='write')
+    open(unit=1, file=trim(outroot) //'Stability_Space.dat', action='write')
     ! do the sampling and save to file:
     allocate(t1(param_number))
     astart = 0.1_dl

--- a/equations_EFT.f90
+++ b/equations_EFT.f90
@@ -1611,6 +1611,8 @@ contains
             EV%eft_cache%EFTISW        = ISW
             EV%eft_cache%EFTLensing    = sources(3)
             EV%eft_cache%CMBTSource    = sources(1)
+            EV%eft_cache%sigmadot      = 1._dl/EV%eft_cache%EFTeomX*(-2._dl*adotoa*(1._dl+EV%eft_cache%EFTeomV)*sigma +etak&
+                & -1._dl/k*dgpi/(1._dl+EV%eft_cache%EFTOmegaV) +EV%eft_cache%EFTeomN/CP%eft_par_cache%h0_Mpc)
             EV%eft_cache%Psi           = ( EV%eft_cache%sigmadot +EV%eft_cache%adotoa*EV%eft_cache%sigma )/k
             EV%eft_cache%Phi           = ( etak -EV%eft_cache%adotoa*EV%eft_cache%sigma )/k
             EV%eft_cache%mu            = -2._dl*k*( EV%eft_cache%sigmadot +EV%eft_cache%adotoa*EV%eft_cache%sigma)/(dgrho)

--- a/equations_EFT.f90
+++ b/equations_EFT.f90
@@ -1604,6 +1604,7 @@ contains
         if ( DebugEFTCAMB ) then
 
             ! compute other things and save them in cache:
+            call CP%EFTCAMB%model%compute_Einstein_Factors( a, CP%eft_par_cache , EV%eft_cache )
             EV%eft_cache%clxc          = clxc
             EV%eft_cache%clxb          = clxb
             EV%eft_cache%vb            = vb
@@ -1611,6 +1612,7 @@ contains
             EV%eft_cache%EFTISW        = ISW
             EV%eft_cache%EFTLensing    = sources(3)
             EV%eft_cache%CMBTSource    = sources(1)
+            EV%eft_cache%sigma         = sigma
             EV%eft_cache%sigmadot      = 1._dl/EV%eft_cache%EFTeomX*(-2._dl*adotoa*(1._dl+EV%eft_cache%EFTeomV)*sigma +etak&
                 & -1._dl/k*dgpi/(1._dl+EV%eft_cache%EFTOmegaV) +EV%eft_cache%EFTeomN/CP%eft_par_cache%h0_Mpc)
             EV%eft_cache%Psi           = ( EV%eft_cache%sigmadot +EV%eft_cache%adotoa*EV%eft_cache%sigma )/k
@@ -1626,7 +1628,7 @@ contains
             end if
 
             ! dump the cache to file:
-            if (CP%EFTCAMB%EFTflag/=0 .and. EV%EFTCAMBactive) then
+            if (CP%EFTCAMB%EFTflag/=0) then
                 call EV%eft_cache%dump_cache_files()
             end if
 


### PR DESCRIPTION
- solved typo with EFT cache printing in debug mode
- EFT cache printing is now compatible with LCDM, when EFTFlag /= 0
